### PR TITLE
$ENV{PROFILE_PER_PAGE} which reset profile counters on each page load

### DIFF
--- a/lib/Plack/Middleware/Profiler/NYTProf.pm
+++ b/lib/Plack/Middleware/Profiler/NYTProf.pm
@@ -19,8 +19,10 @@ sub call {
     $self->report($env);
     $self->end($env);
 
-    warn "FIXME reset profile for each page since we are running CGI";
-    DB::finish_profile();
+    if ( $ENV{PROFILE_PER_PAGE} ) {
+	    warn "FIXME reset profile for each page since we are running CGI";
+	    DB::finish_profile();
+    }
 
     $res;
 }


### PR DESCRIPTION
We are using plack to port CGI application (Koha library system) to plack, and noticed that NYTProf counters keep increasing with each page reload. While this might be useful if you want to profile multi-page application and get summary stats, it does not help when profiling single page since counters seem to grow forever.

Because of that, I introduced new environment variable which will reset counters on each page load.

I'm not sure which behavior should be default, but I'm somewhat biased towards reseting counters and leave current behavior as options. This patch, however, implements opposite solution which is backwards compatible.
