### PR TITLE
Fix disabled bug

### DIFF
--- a/lib/Plack/Middleware/Profiler/NYTProf.pm
+++ b/lib/Plack/Middleware/Profiler/NYTProf.pm
@@ -99,14 +99,14 @@ sub _setup_profiling_hooks {
 sub call {
     my ( $self, $env ) = @_;
 
-    if ( $self->enable_profile->( $self, $env ) ) {
+    if ( $self->enable_profile->() ) {
         $self->before_profile->( $self, $env );
         $self->start_profiling($env);
     }
 
     my $res = $self->app->($env);
 
-    if ( $self->enable_profile->( $self, $env ) ) {
+    if ( $self->enable_profile->() ) {
         $self->stop_profiling($env);
         $self->report($env) if $self->enable_reporting;
         $self->after_profile->( $self, $env );


### PR DESCRIPTION
・disabled のときに、DB::finish_profile が呼ばれてエラーが出てくるのを fix しました。
・enable_profile オプションを呼んでる時の引数をなくしました。
