### PR TITLE
Support prefork app

### DIFF
--- a/examples/app_options.psgi
+++ b/examples/app_options.psgi
@@ -9,7 +9,7 @@ builder {
     # you should execute 'mkdir /tmp/profile' before invoking this PSGI app;
     enable_if { 1 } 'Profiler::NYTProf',
         enable_profile       => sub { 1 },
-        env_nytprof          => 'start=no:file=/tmp/profile/nytprof.out',
+        env_nytprof          => 'start=no:addpid=0:file=/tmp/profile/nytprof.out',
         profiling_result_dir => sub { '/tmp/profile' },
         enable_reporting     => 1;
     $app;


### PR DESCRIPTION
issue に書いた点ですが、prefork な app の場合、parent proc(prepare_app が呼ばれた時点) で load した際に有効だった $ENV{NYTPROF} が、child proc で call された時にはきかないのを修正しました。

report まわり見れてないですが、out ファイルが意図した場所に proc ごとに出せるとこまでは app_options.psgi で試しました。
