### PR TITLE
nytporf.out の不要なパターンで作成されないようにしました

### DIFF
--- a/examples/app_options.psgi
+++ b/examples/app_options.psgi
@@ -2,13 +2,13 @@ use Plack::Builder;
 
 my $app = sub {
     my $env = shift;
-    return [ '200', [ 'Content-Type' => 'text/plain' ], [ "Hello World" ] ];
+    return [ '200', [ 'Content-Type' => 'text/plain' ], [ "Hello World $$" ] ];
 };
 
 builder {
     # you should execute 'mkdir /tmp/profile' before invoking this PSGI app;
     enable_if { 1 } 'Profiler::NYTProf',
-        enable_profile       => sub { 1 },
+        enable_profile       => sub { $$ % 2 == 0 },
         env_nytprof          => 'start=no:addpid=0:file=/tmp/profile/nytprof.out',
         profiling_result_dir => sub { '/tmp/profile' },
         enable_reporting     => 1;

--- a/lib/Plack/Middleware/Profiler/NYTProf.pm
+++ b/lib/Plack/Middleware/Profiler/NYTProf.pm
@@ -97,7 +97,7 @@ my %PROFILER_SETUPED;
 sub call {
     my ( $self, $env ) = @_;
 
-    $self->_setup_profiler unless $PROFILER_SETUPED{$$};
+    $self->_setup_profiler($env) unless $PROFILER_SETUPED{$$};
     $self->start_profiling_if_needed($env);
 
     my $res = $self->app->($env);
@@ -144,7 +144,12 @@ sub stop_profiling_and_report_if_needed {
 }
 
 sub _setup_profiler {
-    my $self = shift;
+    my ( $self, $env ) = @_;
+
+    $PROFILER_SETUPED{$$} = 1;
+
+    my $is_profiler_enabled = $self->enable_profile->($env);
+    return unless $is_profiler_enabled;
 
     $ENV{NYTPROF} = $self->env_nytprof || 'start=no';
 
@@ -152,7 +157,6 @@ sub _setup_profiler {
     # so, we load Devel::NYTProf here.
     require Devel::NYTProf;
     DB::disable_profile();
-    $PROFILER_SETUPED{$$} = 1;
 }
 
 sub start_profiling {


### PR DESCRIPTION
Devel::NYTProf が require されると、nytprof.out が作成されてしまうので、
load するまえに、enable_profile をみる必要がありました。
以前は、$env がないときに enable_profile を呼んでいたので、無条件で
require するようにした記憶がありますが、今は $env があるので、
enable_profile を呼んだ上で　不要ならば load しないとした方が
nytprof.out が無駄に生成されなくて良さそうです。

ちなみに、nytprof.out を完全に作らないようにするには
NYTPROF="file=/dev/null" する必要があります。
ここでファイルを指定すると、指定したファイルと、DB::enable_profile($file) の
両方に書き出すみたいです。
