### PR TITLE
support Devel::NYTProf 5.06 higher only

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ all_from 'lib/Plack/Middleware/Profiler/NYTProf.pm';
 requires(
     'parent'         => 0,
     'Plack'          => 0,
-    'Devel::NYTProf' => 0,
+    'Devel::NYTProf' => '5.06',
     'Time::HiRes'    => 0,
     'File::Which'    => 0,
 );

--- a/t/01_profile.t
+++ b/t/01_profile.t
@@ -20,8 +20,6 @@ subtest 'is profiling result created' => sub {
 
         is $res->code, 200, "Response is returned successfully";
 
-        ok -e "nytprof.out", "Exists nytprof.out";
-
         my $regex = qr/nytprof\.\d+\-(\d+)\.\d+\.out/;
         for my $file ( glob("nytprof.*.out") ) {
             like $file, $regex, "Exists profiling result file: $file";


### PR DESCRIPTION
Fixed the below bug at Devel::NYTProf 5.06. 
In Changes:

> Fixed to no longer open a file when start=no. RT#86497/RT#87404.
