### PR TITLE
Almost revert c:bb890f3.

### DIFF
--- a/lib/Plack/Middleware/Profiler/NYTProf.pm
+++ b/lib/Plack/Middleware/Profiler/NYTProf.pm
@@ -37,13 +37,6 @@ sub prepare_app {
     $self->_setup_enable_reporting;
     $self->_setup_report_dir;
     $self->_setup_nytprofhtml_path;
-
-    $ENV{NYTPROF} = $self->env_nytprof || 'start=no:sigexit=int';
-
-    # NYTPROF environment variable is set in Devel::NYTProf::Core
-    # so, we load Devel::NYTProf here.
-    require Devel::NYTProf;
-    DB::disable_profile();
 }
 
 sub _setup_profiling_file_paths {
@@ -166,6 +159,16 @@ sub _setup_profiler {
     my $pid = $$;
     return if $PROFILER_SETUPED{$pid};
     $PROFILER_SETUPED{$pid} = 1;
+
+    my $is_profiler_enabled = $self->enable_profile->($env);
+    return unless $is_profiler_enabled;
+
+    $ENV{NYTPROF} = $self->env_nytprof || 'start=no:sigexit=int';
+
+    # NYTPROF environment variable is set in Devel::NYTProf::Core
+    # so, we load Devel::NYTProf here.
+    require Devel::NYTProf;
+    DB::disable_profile();
 }
 
 sub start_profiling {

--- a/t/03_no_load.t
+++ b/t/03_no_load.t
@@ -1,0 +1,42 @@
+use strict;
+use Plack::Middleware::Profiler::NYTProf;
+use Test::More;
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+use t::Util;
+
+
+subtest 'No load Devel::NYTProf' => sub {
+    my $result_dir      = tempdir();
+    my $result_filename = $$;
+
+    my $app = Plack::Middleware::Profiler::NYTProf->wrap(
+        sub {
+            my $env = shift;
+
+            my $find = 0;
+            for my $pm (keys %INC) {
+                $find = 1 if $pm eq 'Devel/NYTProf.pm';
+            }
+            return [ '200', [ 'Content-Type' => 'text/plain' ], ["$find"] ];
+        },
+        enable_profile   => sub { 0 },
+        enable_reporting => 0,
+    );
+
+    test_psgi $app, sub {
+        my $cb  = shift;
+        my $res = $cb->( GET "/" );
+
+        is $res->code, 200, "Response is returned successfully";
+        is $res->content, '0', 'No load Devel::NYTProf';
+
+        ok !-e "nytprof.out", "Doesn't exist nytprof.out";
+        ok !-e path( "report", "index.html" ), "Doesn't exist report file";
+    };
+
+    unlink glob("nytprof*.out");
+};
+
+done_testing;


### PR DESCRIPTION
Because the 'prepare_app' method is invoked on load phase for an app.
So Devel::NYTProf is loaded too.
I expect that Devel::NYTProf does not load without 'enabled setting'.
