### PR TITLE
This is a workaround for passing tests.

### DIFF
--- a/t/03_no_load.t
+++ b/t/03_no_load.t
@@ -4,8 +4,11 @@ use Test::More;
 use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
+use File::Which qw(which);
 use t::Util;
 
+my $bin = scalar which 'nytprofhtml';
+plan skip_all => 'nytprofhtml script is not in your PATH.' unless defined $bin;
 
 subtest 'No load Devel::NYTProf' => sub {
     my $result_dir      = tempdir();


### PR DESCRIPTION
There are several systems without nytprofhtml command.