### PR TITLE
No need to set 'nytprofhtml' when 'enable_reporting' is false.

### DIFF
--- a/lib/Plack/Middleware/Profiler/NYTProf.pm
+++ b/lib/Plack/Middleware/Profiler/NYTProf.pm
@@ -83,6 +83,7 @@ sub _setup_report_dir {
 
 sub _setup_nytprofhtml_path {
     my $self = shift;
+    return if !$self->enable_reporting;
     return if $self->nytprofhtml_path;
     my $nytprofhtml_path = File::Which::which('nytprofhtml')
         or die "Could not find nytprofhtml script. Ensure it's in your path";
@@ -162,7 +163,12 @@ sub stop_profiling_and_report_if_needed {
     return unless $is_profiler_enabled;
 
     $self->stop_profiling($env);
-    $self->report($env) if $self->enable_reporting;
+    if ($self->enable_reporting) {
+        if (!$self->nytprofhtml_path) {
+            $self->_setup_nytprofhtml_path;
+        }
+        $self->report($env);
+    }
     $self->after_profile->( $self, $env );
 }
 

--- a/t/01_profile.t
+++ b/t/01_profile.t
@@ -4,11 +4,7 @@ use Test::More;
 use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
-use File::Which qw(which);
 use t::Util;
-
-my $bin = scalar which 'nytprofhtml';
-plan skip_all => 'nytprofhtml script is not in your PATH.' unless defined $bin;
 
 subtest 'is profiling result created' => sub {
     my $app = Plack::Middleware::Profiler::NYTProf->wrap( simple_app(),

--- a/t/02_profile_options.t
+++ b/t/02_profile_options.t
@@ -4,11 +4,7 @@ use Test::More;
 use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
-use File::Which qw(which);
 use t::Util;
-
-my $bin = scalar which 'nytprofhtml';
-plan skip_all => 'nytprofhtml script is not in your PATH.' unless defined $bin;
 
 # FIXME Need to check profile format version 
 # The report isn't generated if profile format version isn't matched. 

--- a/t/03_no_load.t
+++ b/t/03_no_load.t
@@ -4,11 +4,7 @@ use Test::More;
 use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
-use File::Which qw(which);
 use t::Util;
-
-my $bin = scalar which 'nytprofhtml';
-plan skip_all => 'nytprofhtml script is not in your PATH.' unless defined $bin;
 
 subtest 'No load Devel::NYTProf' => sub {
     my $result_dir      = tempdir();

--- a/t/04_preload.t
+++ b/t/04_preload.t
@@ -3,11 +3,7 @@ use Test::More;
 use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
-use File::Which qw(which);
 use t::Util;
-
-my $bin = scalar which 'nytprofhtml';
-plan skip_all => 'nytprofhtml script is not in your PATH.' unless defined $bin;
 
 BEGIN {
     use Plack::Middleware::Profiler::NYTProf;


### PR DESCRIPTION
lazy get the path of 'nytprofhtml'.
